### PR TITLE
Fix sticker rotations for valid cube states

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,16 +291,16 @@
           counterClockwise: [['up', [0, 3, 6]], ['back', [8, 5, 2]], ['down', [0, 3, 6]], ['front', [0, 3, 6]]]
         },
         right: {
-          clockwise: [['up', [8, 5, 2]], ['back', [0, 3, 6]], ['down', [8, 5, 2]], ['front', [8, 5, 2]]],
-          counterClockwise: [['up', [8, 5, 2]], ['front', [8, 5, 2]], ['down', [8, 5, 2]], ['back', [0, 3, 6]]]
+          clockwise: [['up', [2, 5, 8]], ['back', [6, 3, 0]], ['down', [2, 5, 8]], ['front', [2, 5, 8]]],
+          counterClockwise: [['up', [2, 5, 8]], ['front', [2, 5, 8]], ['down', [2, 5, 8]], ['back', [6, 3, 0]]]
         },
         up: {
-          clockwise: [['back', [0, 1, 2]], ['right', [0, 1, 2]], ['front', [0, 1, 2]], ['left', [0, 1, 2]]],
-          counterClockwise: [['back', [0, 1, 2]], ['left', [0, 1, 2]], ['front', [0, 1, 2]], ['right', [0, 1, 2]]]
+          clockwise: [['front', [0, 1, 2]], ['right', [0, 1, 2]], ['back', [2, 1, 0]], ['left', [0, 1, 2]]],
+          counterClockwise: [['front', [0, 1, 2]], ['left', [0, 1, 2]], ['back', [2, 1, 0]], ['right', [0, 1, 2]]]
         },
         down: {
-          clockwise: [['front', [6, 7, 8]], ['right', [6, 7, 8]], ['back', [6, 7, 8]], ['left', [6, 7, 8]]],
-          counterClockwise: [['front', [6, 7, 8]], ['left', [6, 7, 8]], ['back', [6, 7, 8]], ['right', [6, 7, 8]]]
+          clockwise: [['front', [6, 7, 8]], ['left', [6, 7, 8]], ['back', [8, 7, 6]], ['right', [6, 7, 8]]],
+          counterClockwise: [['front', [6, 7, 8]], ['right', [6, 7, 8]], ['back', [8, 7, 6]], ['left', [6, 7, 8]]]
         }
       };
 


### PR DESCRIPTION
## Summary
- update face adjacency tables in `index.html`
- ensure rotations of `right`, `up`, and `down` match a real Rubik's Cube

## Testing
- `node -e "const Cube=require('./libs/solve'); console.log('loaded')"`

------
https://chatgpt.com/codex/tasks/task_e_68686451f14c832db30f4020efe350aa