### PR TITLE
Use preview classes for ghost pieces

### DIFF
--- a/script.js
+++ b/script.js
@@ -131,10 +131,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const piece = currentPieces[selectedPieceIndex];
         if (!piece || piece.played) return;
         const isValid = canPlacePiece(piece, row, col);
-        const color = isValid ? neonColors.previewValid : neonColors.previewInvalid;
 
         // Dibujar "fantasma"
-        drawGhost(piece, row, col, color);
+        drawGhost(piece, row, col, isValid);
     }
 
     function handleMouseLeave() {
@@ -142,7 +141,7 @@ document.addEventListener('DOMContentLoaded', () => {
         refreshBoardView();
     }
 
-    function drawGhost(piece, startRow, startCol, color) {
+    function drawGhost(piece, startRow, startCol, isValid) {
         refreshBoardView();
         for (let i = 0; i < piece.shape.length; i++) {
             for (let j = 0; j < piece.shape[0].length; j++) {
@@ -154,7 +153,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             `.cell[data-row="${targetRow}"][data-col="${targetCol}"]`
                         );
                         if (cell) {
-                            cell.style.backgroundColor = color;
+                            cell.classList.add(isValid ? 'preview-valid' : 'preview-invalid');
                         }
                     }
                 }
@@ -166,6 +165,7 @@ document.addEventListener('DOMContentLoaded', () => {
         for (let i = 0; i < boardSize; i++) {
             for (let j = 0; j < boardSize; j++) {
                 const cell = document.querySelector(`.cell[data-row="${i}"][data-col="${j}"]`);
+                cell.classList.remove('preview-valid', 'preview-invalid');
                 cell.style.backgroundColor = board[i][j] ?? '';
             }
         }


### PR DESCRIPTION
### Motivation
- Mejorar la visibilidad de las zonas de "caída" del fantasma usando las clases CSS existentes que añaden borde y escala, en lugar de pintar solo el fondo.
- Actualmente el script aplicaba directamente `style.backgroundColor`, lo que no muestra el borde neón ni el pequeño escalado definido en `styles.css`.

### Description
- Cambiado `handleMouseEnter` para calcular `isValid` y pasar ese booleano a `drawGhost` en vez de un `color`.
- Modificada la firma de `drawGhost` a `drawGhost(piece, startRow, startCol, isValid)` y ahora añade la clase `preview-valid` o `preview-invalid` con `classList.add` en lugar de usar `style.backgroundColor`.
- Actualizada `refreshBoardView` para eliminar las clases de preview (`preview-valid`, `preview-invalid`) antes de restaurar el color base del tablero.
- Se actualizó y commitió `script.js` con los cambios mencionados para integrar el comportamiento visual con el CSS existente.

### Testing
- Levantado un servidor local con `python -m http.server 8000` para probar la UI manualmente (sucedido).
- Intento de prueba visual automatizada con Playwright para hacer hover y capturar una captura de pantalla que terminó en timeout (falló).
- Reintento de Playwright falló con un crash del navegador (SIGSEGV) durante el lanzamiento (falló).
- No se ejecutaron tests unitarios automatizados en este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69529710a55c832daacdd438c28ad7d4)